### PR TITLE
path.py removed path.path in 0.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ nosexcover
 rednose
 requests==0.14.1
 boto==2.6.0
-path.py
+path.py==0.10
 dogstatsd-python==0.2.1
 south
 anyjson==0.3.3

--- a/settings.py
+++ b/settings.py
@@ -3,10 +3,10 @@
 import json
 import os
 from logsettings import get_logger_config
-from path import path
+from path import Path
 import sys
 
-ROOT_PATH = path(__file__).dirname()
+ROOT_PATH = Path(__file__).dirname()
 REPO_PATH = ROOT_PATH
 ENV_ROOT = REPO_PATH.dirname()
 

--- a/tests/test-runserver.py
+++ b/tests/test-runserver.py
@@ -12,7 +12,6 @@ import json
 import logging
 import os
 import os.path
-from path import path
 import requests
 import sys
 import time

--- a/tests/test.py
+++ b/tests/test.py
@@ -11,7 +11,6 @@ import glob
 import json
 import os
 import os.path
-from path import path
 import pprint
 import requests
 import sys


### PR DESCRIPTION
They did this in 0.8 but reverted it, and did it for real now.

https://github.com/jaraco/path.py/blob/master/CHANGES.rst#100

@edx/devops this was breaking CI (we can't start xserver)

@edx/platform-team FYI since I think xserver belongs to you folks.