### PR TITLE
Update requests.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pika
 django_nose==1.4.1
 nosexcover
 rednose
-requests==0.14.1
+requests==2.13.0
 boto==2.6.0
 path.py==10.0
 dogstatsd-python==0.2.1


### PR DESCRIPTION
The old version of requests broke when we tried to install it with the new version of setuptools.  We don't use request in any complex ways so we should just upgrade it.

@edx/devops @nedbat 

Changelog in case anyone wants it: https://pypi.python.org/pypi/requests/